### PR TITLE
Fix errors on _mouse_moved if plot is not visible

### DIFF
--- a/finplot/__init__.py
+++ b/finplot/__init__.py
@@ -2043,8 +2043,8 @@ def _mouse_moved(master, evs):
     master_data[master]['last_mouse_y'] = y
     # apply to all crosshairs
     for ax in master.axs:
-        point = ax.vb.mapSceneToView(pos)
-        if ax.crosshair:
+        if ax.isVisible() and ax.crosshair:
+            point = ax.vb.mapSceneToView(pos)
             ax.crosshair.update(point)
 
 


### PR DESCRIPTION
When a PlotItem (ax) is hidden (using `ax.hide()`), the `_mouse_move` handler will throw non-fatal exceptions when trying to map mouse position to ViewBox. This fix adds a check to see if the PlotItem is visible before trying to update the crosshair.