### PR TITLE
300x speed improvement on pdtime2index

### DIFF
--- a/finplot/__init__.py
+++ b/finplot/__init__.py
@@ -2124,10 +2124,17 @@ def _pdtime2index(ax, ts, any_end=False, require_time=False):
             ts = ts.astype('float64') / 1e3
         elif h < 1e10: # handle s epochs
             ts = ts.astype('float64') * 1e3
-    r = []
+    
     datasrc = _get_datasrc(ax)
+    xs = datasrc.x
+
+    # try exact match before approximate match
+    exact = datasrc.index[datasrc.x.isin(ts)].to_list()
+    if len(exact) == len(ts):
+        return exact
+    
+    r = []
     for i,t in enumerate(ts):
-        xs = datasrc.x
         xss = xs.loc[xs>t]
         if len(xss) == 0:
             t0 = xs.iloc[-1]

--- a/finplot/__init__.py
+++ b/finplot/__init__.py
@@ -2129,7 +2129,7 @@ def _pdtime2index(ax, ts, any_end=False, require_time=False):
     xs = datasrc.x
 
     # try exact match before approximate match
-    exact = datasrc.index[datasrc.x.isin(ts)].to_list()
+    exact = datasrc.index[xs.isin(ts)].to_list()
     if len(exact) == len(ts):
         return exact
     


### PR DESCRIPTION
`_pdtime2index` is quite slow for large datasets due to the approximation algorithm. However, there are use cases when no approximation is necessary and an exact match is available. In those cases, shortcircuit the approximation and return the exact match for a 300x improvement in speed.

Large dataset:

```
len(fplt._get_datasrc(ax).df)
> 398611
```

Needles in haystack:

```
len(exact_dt)
> 523
```

Original speed:

```
%time fplt._pdtime2index(ax, exact_dt)
> Wall time: 1.66 s
```

Updated speed:

```
%time fplt._pdtime2index2(ax, exact_dt)
> Wall time: 5.38 ms
```

Exact same output:

```
fplt._pdtime2index(ax, exact_dt) == fplt._pdtime2index2(ax, exact_dt)
> True
```

Including still working for approximation method:

```
fplt._pdtime2index(ax, shifted_dt) == fplt._pdtime2index2(ax, shifted_dt)
> True
```