### PR TITLE
Changed some FinWindow checks to GraphicsLayoutWidget

### DIFF
--- a/finplot/__init__.py
+++ b/finplot/__init__.py
@@ -1163,7 +1163,7 @@ def create_plot_widget(master, rows=1, init_zoom_periods=1e10, yscale='linear'):
         else:
             viewbox.setFocus()
         axs += [ax]
-    if isinstance(master, FinWindow):
+    if isinstance(master, pg.GraphicsLayoutWidget):
         proxy = pg.SignalProxy(master.scene().sigMouseMoved, rateLimit=144, slot=partial(_mouse_moved, master))
     else:
         proxy = []
@@ -1655,7 +1655,7 @@ def _create_plot(ax=None, **kwargs):
 
 
 def _add_timestamp_plot(master, prev_ax, viewbox, index, yscale):
-    native_win = isinstance(master, FinWindow)
+    native_win = isinstance(master, pg.GraphicsLayoutWidget)
     if native_win and prev_ax is not None:
         prev_ax.set_visible(xaxis=False) # hide the whole previous axis
     axes = {'bottom': EpochAxisItem(vb=viewbox, orientation='bottom'),


### PR DESCRIPTION
The embedding workflow (call `create_plot_widget` directly then lay it out) assumes that the desired return item is a single PlotWidget. There are use cases where in fact the caller already has a layout widget, and wants some `PlotItems` instead.

The ideal fix here is to allow the caller to specify into `create_plot_widget` the desired result, whilst remaining backwards compatible, however I'm not sufficiently comfortable making this change. Instead, I've continued to allow finplot to _infer_ that the parent is a layout already, and therefore to create an item instead.

This is done in the simplest possible way, change the checks from `FinWindow` (a native window) to `pg.GraphicsLayoutWidget` (the most convenient layout widget class in `pygtgraph` and the parent class of `FinWindow`). This makes embedding use cases where the parent is any subclass of `pg.GraphicsLayoutWidget` work.