### PR TITLE
close_widget function, allows closing of widget out of finplot.

### DIFF
--- a/finplot/__init__.py
+++ b/finplot/__init__.py
@@ -1283,6 +1283,22 @@ def close():
     sounds.clear()
     master_data.clear()
     last_ax = None
+   
+    
+def close_widget(widget):
+    """ create_plot_widget returns a plot_widget, which can be attached to a QGraphicsView layout for showing in PyQt5 application. 
+        Everytime when a window is created, it is added to a global list, if it is not there. That means, to attach a plot_widget
+        in QgraphicsView, we need re-use same QGraphicsView widget else it will keep on adding to window list, thus leaking memory.
+        Freeing the widget leads to C/C++ object of ViewBox has been deleted error (or comment of fplt.show)
+        
+        Solution: remove item from windows list since fplt.show goes through it completely."""
+    global windows
+    if widget in windows:
+        windows.remove(widget)
+            # widget.deleteLater() / sip.delete(widget) can be manually added depending on use-case.
+            # if creating a new chart just after deleting, use deleteLater. sip.delete removes window completely
+            # leading to a few milliseconds of blank screen
+       
 
 
 def price_colorfilter(item, datasrc, df):


### PR DESCRIPTION
This seems to solve the issue I had opened. The comment sort of explains it all.

*Issue:*

```
def plotSomething():
    if not plot_ha:
        (gv, list_ax) = blankGraphicsViewWidget(gv=gv, alignment=alignment, num_rows=1,  init_zoom_periods=init_zoom_periods)
        ax_candle = list_ax        
    plot_cs = _plotCandles(df, ax_candle)
    if fplt_show: ## it is required in normal charts, but gives error in dialog
        fplt.show(qt_exec=False) ## c/c++ object error
    else:
        gv.show()
    return (gv, plot_cs, ax_candle)
    
    
    
def   blankGraphicsViewWidget():
    if gv is None:
        graphics_view = QGraphicsView() 
    else:
        graphics_view = gv
    
 if alignment == "horizontal":
        hbox = QHBoxLayout()
    else:
        hbox = QVBoxLayout()
    
    w = fplt.create_plot_widget(graphics_view.window(), 
                                rows=num_rows, 
                                init_zoom_periods=init_zoom_periods)
    list_axs = []  
    if num_rows == 1:
        list_axs = [w]
    else:
        for i in w:
            list_axs.append(i)

    for i in list_axs:
        hbox.addWidget(i.ax_widget)
        i.set_visible(crosshair=True, xaxis=True, yaxis=True, xgrid=True, ygrid=True)
           
    graphics_view.window().axs = list_axs       # finplot requres this property
    graphics_view.setLayout(hbox)
    return (graphics_view, w)    

```


```blankGraphicsViewWidget``` returns a QGraphicsView with the plot, but creating multiple plots leads to memory leak as each of them seems to be stored in the ```windows``` variable. 
Removing the widget using ```deleteLater``` or ```sip.delete``` ends up with ```c/c++ object for FinViewBox is deleted``` pointing to the line ```flpt.show(qt.exec_=False)```.

Without that line, the graphs are too glitchy. So to help I added ```gv.show()```, essentially what that does, but it is slow like creation takes time but zoom and other stuff seem to work.

So, i just added a few lines that allow us to remove the widget from ```windows``` and thus we can safely delete it out of finplot and seems to me an appropriate response. Do let me know if i am doing something wrong.

