### PR TITLE
Disable scrolling of the plots during mouseLeftDrag

### DIFF
--- a/finplot/__init__.py
+++ b/finplot/__init__.py
@@ -629,6 +629,7 @@ class FinViewBox(pg.ViewBox):
         self.v_zoom_scale = v_zoom_scale
         self.master_viewbox = None
         self.rois = []
+        self.isMouseLeftDrag = False
         self.reset()
 
     def reset(self):
@@ -708,6 +709,10 @@ class FinViewBox(pg.ViewBox):
         '''Ctrl+LButton draw lines.'''
         if ev.modifiers() != QtCore.Qt.ControlModifier:
             super().mouseDragEvent(ev, axis)
+            if ev.isFinish():
+                self.isMouseLeftDrag = False
+            else:
+                self.isMouseLeftDrag = True
             if ev.isFinish() or self.drawing:
                 self.refresh_all_y_zoom()
             if not self.drawing:
@@ -2199,7 +2204,7 @@ def _update_gfx(item):
         i.datasrc.set_df(df_clipped)
         break
     update_sigdig = False
-    if not item.datasrc.standalone:
+    if not item.datasrc.standalone and not item.ax.vb.isMouseLeftDrag:
         # new limits when extending/reducing amount of data
         x_min,x1 = _set_x_limits(item.ax, item.datasrc)
         # scroll all plots if we're at the far right


### PR DESCRIPTION
This commit disables the automatic scrolling of the chart while we drag the chart with mouse left button. This allows users to smoothly drag the chart left and right without any automatic scrolling interference during the drag operation.

I had noticed that in realtime chart, when I was at far right I couldn't drag the chart to the right slowly because as soon as new data arrived the plots scrolled to the left automatically. I could only drag the chart to the right when I did so quickly.