### PR TITLE
Hide crosshair when mouse pointer is not over the plot otherwise show it

### DIFF
--- a/finplot/__init__.py
+++ b/finplot/__init__.py
@@ -439,6 +439,7 @@ class FinCrossHair:
         self.hline.setZValue(50)
         self.xtext.setZValue(50)
         self.ytext.setZValue(50)
+        self._isEnabled = True  # by default crosshair is enabled.
         self.hide()  # hide crosshair until user intentionally moves mouse pointer over the plot.
         self.addToPlot()
 
@@ -506,14 +507,32 @@ class FinCrossHair:
         self.ax.addItem(self.xtext, ignoreBounds=True)
         self.ax.addItem(self.ytext, ignoreBounds=True)
         
-    def show(self):
-        if self.vline in self.ax.items:
-            self.vline.show()
-            self.hline.show()
-            self.xtext.show()
-            self.ytext.show()
-        else:
+    def enable(self):
+        if self._isEnabled:
+            return
+        self._isEnabled = True
+        if self.vline not in self.ax.items:
             self.addToPlot()
+
+    def disable(self):
+        if self._isEnabled == False:
+            return
+        self._isEnabled = False
+        if self.vline in self.ax.items:
+            self.ax.removeItem(self.xtext)
+            self.ax.removeItem(self.ytext)
+            self.ax.removeItem(self.vline)
+            self.ax.removeItem(self.hline)
+
+    def show(self):
+        if self._isEnabled:
+            if self.vline in self.ax.items:
+                self.vline.show()
+                self.hline.show()
+                self.xtext.show()
+                self.ytext.show()
+            else:
+                self.addToPlot()
 
     def hide(self):
         self.vline.hide()
@@ -1935,9 +1954,11 @@ def _ax_overlay(ax, scale=0.25, yaxis=False):
     return axo
 
 
-def _ax_set_visible(ax, crosshair=None, xaxis=None, yaxis=None, xgrid=None, ygrid=None):
-    if crosshair == False:
-        ax.crosshair.hide()
+def _ax_set_visible(ax, crosshair=True, xaxis=None, yaxis=None, xgrid=None, ygrid=None):
+    if crosshair == True:
+        ax.crosshair.enable()
+    else:
+        ax.crosshair.disable()
     if xaxis is not None:
         ax.getAxis('bottom').setStyle(showValues=xaxis)
     if yaxis is not None:

--- a/finplot/__init__.py
+++ b/finplot/__init__.py
@@ -387,7 +387,7 @@ class FinWindow(pg.GraphicsLayoutWidget):
         self.setGeometry(winx, winy, winw, winh)
         winx += 40
         winy += 40
-        self.centralWidget.installEventFilter(self)
+        self.installEventFilter(self)
         self.ci.setContentsMargins(0, 0, 0, 0)
         self.ci.setSpacing(-1)
         self.closing = False
@@ -403,9 +403,19 @@ class FinWindow(pg.GraphicsLayoutWidget):
         return super().close()
 
     def eventFilter(self, obj, ev):
-        if ev.type()== QtCore.QEvent.WindowDeactivate:
+        if ev.type() == QtCore.QEvent.Enter:
+            for ax in self.ci.items:
+                if isinstance(ax, pg.PlotItem):
+                    if ax.crosshair is not None:
+                        ax.crosshair.show()
+        elif ev.type() == QtCore.QEvent.Leave:
+            for ax in self.ci.items:
+                if isinstance(ax, pg.PlotItem):
+                    if ax.crosshair is not None:
+                        ax.crosshair.hide()
+        elif ev.type() == QtCore.QEvent.WindowDeactivate:
             _savewindata(self)
-        return False
+        return super(FinWindow, self).eventFilter(obj, ev)
 
     def leaveEvent(self, ev):
         if not self.closing:

--- a/finplot/__init__.py
+++ b/finplot/__init__.py
@@ -439,7 +439,14 @@ class FinCrossHair:
         self.hline.setZValue(50)
         self.xtext.setZValue(50)
         self.ytext.setZValue(50)
-        self.show()
+        self.vline.hide()
+        self.hline.hide()
+        self.xtext.hide()
+        self.ytext.hide()
+        self.ax.addItem(self.vline, ignoreBounds=True)
+        self.ax.addItem(self.hline, ignoreBounds=True)
+        self.ax.addItem(self.xtext, ignoreBounds=True)
+        self.ax.addItem(self.ytext, ignoreBounds=True)
 
     def update(self, point=None):
         if point is not None:
@@ -500,16 +507,16 @@ class FinCrossHair:
         self.ytext.setText(ytext)
 
     def show(self):
-        self.ax.addItem(self.vline, ignoreBounds=True)
-        self.ax.addItem(self.hline, ignoreBounds=True)
-        self.ax.addItem(self.xtext, ignoreBounds=True)
-        self.ax.addItem(self.ytext, ignoreBounds=True)
+        self.vline.show()
+        self.hline.show()
+        self.xtext.show()
+        self.ytext.show()
 
     def hide(self):
-        self.ax.removeItem(self.xtext)
-        self.ax.removeItem(self.ytext)
-        self.ax.removeItem(self.vline)
-        self.ax.removeItem(self.hline)
+        self.vline.hide()
+        self.hline.hide()
+        self.xtext.hide()
+        self.ytext.hide()
 
 
 

--- a/finplot/__init__.py
+++ b/finplot/__init__.py
@@ -439,14 +439,8 @@ class FinCrossHair:
         self.hline.setZValue(50)
         self.xtext.setZValue(50)
         self.ytext.setZValue(50)
-        self.vline.hide()
-        self.hline.hide()
-        self.xtext.hide()
-        self.ytext.hide()
-        self.ax.addItem(self.vline, ignoreBounds=True)
-        self.ax.addItem(self.hline, ignoreBounds=True)
-        self.ax.addItem(self.xtext, ignoreBounds=True)
-        self.ax.addItem(self.ytext, ignoreBounds=True)
+        self.hide()  # hide crosshair until user intentionally moves mouse pointer over the plot.
+        self.addToPlot()
 
     def update(self, point=None):
         if point is not None:
@@ -506,11 +500,20 @@ class FinCrossHair:
         self.xtext.setText(xtext)
         self.ytext.setText(ytext)
 
+    def addToPlot(self):
+        self.ax.addItem(self.vline, ignoreBounds=True)
+        self.ax.addItem(self.hline, ignoreBounds=True)
+        self.ax.addItem(self.xtext, ignoreBounds=True)
+        self.ax.addItem(self.ytext, ignoreBounds=True)
+        
     def show(self):
-        self.vline.show()
-        self.hline.show()
-        self.xtext.show()
-        self.ytext.show()
+        if self.vline in self.ax.items:
+            self.vline.show()
+            self.hline.show()
+            self.xtext.show()
+            self.ytext.show()
+        else:
+            self.addToPlot()
 
     def hide(self):
         self.vline.hide()


### PR DESCRIPTION
This commit lets finplot to show crosshair(if enabled) when the mouse pointer is over the plot else hide the crosshair to reduce the clutter produced by it.