### PR TITLE
strip the last '+' for HeatmapItem

### DIFF
--- a/finplot/__init__.py
+++ b/finplot/__init__.py
@@ -1279,8 +1279,19 @@ class HeatmapItem(FinPlotItem):
 
     def generate_picture(self, boundingRect):
         prices = self.datasrc.df.columns[self.datasrc.col_data_offset:self.col_data_end]
-        h0 = (prices[0] - prices[1]) * (1-self.rect_size)
-        h1 = (prices[0] - prices[1]) * (1-(1-self.rect_size)*2)
+
+        price_is_str = False
+        if isinstance(prices[0], str):
+            price_is_str = True
+            # strip the last '+'
+            price0 = prices[0][:-1]
+            price1 = prices[1][:-1]
+            h0 = (float(price0) - float(price1)) * (1-self.rect_size)
+            h1 = (float(price0) - float(price1)) * (1-(1-self.rect_size)*2)
+        else:
+            h0 = (prices[0] - prices[1]) * (1-self.rect_size)
+            h1 = (prices[0] - prices[1]) * (1-(1-self.rect_size)*2)
+
         rect_size2 = 0.5 * self.rect_size
         df = self.datasrc.df.iloc[:, self.datasrc.col_data_offset:self.col_data_end]
         values = df.values
@@ -1295,6 +1306,11 @@ class HeatmapItem(FinPlotItem):
                 if v >= lim:
                     v = 1 - self.colcurve(1 - (v-lim)/(1-lim))
                     color = self.colmap.map(v, mode='qcolor')
+                    if price_is_str:
+                        # strip the last '+'
+                        price_s = price[:-1]
+                        price = float(price_s)
+
                     p.fillRect(QtCore.QRectF(t-rect_size2, self.ax.vb.yscale.invxform(price+h0), self.rect_size, self.ax.vb.yscale.invxform(h1)), color)
 
 


### PR DESCRIPTION
strip the last '+' for HeatmapItem

where trying to update the Heatmap, there would be crash which is due to an appended '+' after the column name.

(it is an ugly fix, I am not sure a better solution to this.)

